### PR TITLE
Update devcontainer.json to use shopify ruby extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,8 @@
         "eamodio.gitlens",
         "IBM.output-colorizer",
         "castwide.solargraph",
-        "rebornix.Ruby",
-        "wingrunr21.vscode-ruby",
+        "Shopify.ruby-extensions-pack",
+        "Shopify.ruby-lsp",
         "bung87.vscode-gemfile",
         "vscode-icons-team.vscode-icons"
       ],


### PR DESCRIPTION
Replace deprecated extensions:
- `rebornix.Ruby` into `Shopify.ruby-extensions-pack`
- `wingrunr21.vscode-ruby` into `Shopify.ruby-lsp`